### PR TITLE
Local Development

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "conventionalCommits.scopes": [
-        "local"
-    ]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "conventionalCommits.scopes": [
+        "local"
+    ]
+}

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -6,10 +6,12 @@
 
 // You can delete this file if you're not using it
 const React = require("react")
-
+// added id to head, this avoids the error in gatsby develop
 exports.onRenderBody = ({ setHeadComponents }) => {
+  
   setHeadComponents([
     <script
+      key="testId"
       dangerouslySetInnerHTML={{
         __html: `
   (function() {

--- a/src/components/table-of-contents.js
+++ b/src/components/table-of-contents.js
@@ -8,7 +8,7 @@ function renderItems(items, level, episodePath) {
       item =>
       (  <>
          { item.title && 
-            <li key={item.url}> <a href={`${item.url}`} title={item.title}>
+            <li key={episodePath}> <a href={`${item.url}`} title={item.title}>
             <span>{item.title}</span>
           </a>
           


### PR DESCRIPTION
`gatsby develop` was giving an error locally:

Each child in a list should have a unique "key" prop' warning.

This is fixed by adding `key` to head in `gatsby-config`