### PR TITLE
Warning with compiling LaTeX

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -54,7 +54,13 @@ module.exports = {
             },
           },
           `gatsby-remark-copy-linked-files`,
-          `gatsby-remark-katex`,
+          {
+            resolve:`gatsby-remark-katex`,
+          options: {
+            // Add any KaTeX options to avoid LaTex newline warning 
+            strict: `ignore`
+            }
+          },
         ],
       },
     },


### PR DESCRIPTION
This error is caused by using `\newline` in LaTex. This has been fixed in the  `gatsby.config` by setting options to not strict

`warn LaTeX-incompatible input and strict mode is set to 'warn': In LaTeX, \\ or \newline does nothing in display mode [newLineInDisplayMode]`